### PR TITLE
Update to package format 3 and run xmllint

### DIFF
--- a/delphi_srr2_radar_driver_wrapper/CMakeLists.txt
+++ b/delphi_srr2_radar_driver_wrapper/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(delphi_srr2_radar_driver_wrapper)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 

--- a/delphi_srr2_radar_driver_wrapper/package.xml
+++ b/delphi_srr2_radar_driver_wrapper/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>delphi_srr2_radar_driver_wrapper</name>
   <version>1.0.0</version>
   <description>The delphi srr2 radar driver wrapper package</description>


### PR DESCRIPTION
Update remaining packages that had package format version 2 to version 3 and address any xmllint issues when testing against the package format v3 schema (typically just reordering items).